### PR TITLE
Fix analyzer warnings.

### DIFF
--- a/APING iOS SDK/Categories/NSString+URLEncoding.m
+++ b/APING iOS SDK/Categories/NSString+URLEncoding.m
@@ -32,7 +32,7 @@
 
 - (NSString *)urlEncodedString
 {
-    return (__bridge NSString *)CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault,
+    return (__bridge_transfer NSString *)CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault,
                                                                         (__bridge CFStringRef)self,
                                                                         NULL,
                                                                         (CFStringRef)@"!*'\"();:@&=+$,/?%#[]% ",
@@ -41,7 +41,7 @@
 
 - (NSString *)urlDecodedString
 {
-    return (__bridge NSString *)CFURLCreateStringByReplacingPercentEscapesUsingEncoding(NULL,
+    return (__bridge_transfer NSString *)CFURLCreateStringByReplacingPercentEscapesUsingEncoding(NULL,
                                                                                         (__bridge CFStringRef)self,
                                                                                         (CFStringRef)@"",
                                                                                         kCFStringEncodingUTF8);

--- a/APING iOS SDK/Classes/BNGMutableURLRequest.h
+++ b/APING iOS SDK/Classes/BNGMutableURLRequest.h
@@ -58,7 +58,8 @@ typedef NS_ENUM(NSInteger, APINGErrorCode) {
  * Sets the parameters parameter as the body of the POST request.
  * @param parameters key/value pairs which should be sent as part of the POST request.
  * @param error JSON Encoding error if any.
+ * @return success
  */
-- (void)setPostParameters:(NSDictionary *)parameters error:(NSError *__autoreleasing *)error;
+- (BOOL)setPostParameters:(NSDictionary *)parameters error:(NSError *__autoreleasing *)error;
 
 @end

--- a/APING iOS SDK/Classes/BNGMutableURLRequest.m
+++ b/APING iOS SDK/Classes/BNGMutableURLRequest.m
@@ -86,7 +86,7 @@ static const struct BNGDefaultParameterField BNGDefaultParameterField = {
     [self setPostParameters:parameters error:nil];
 }
 
-- (void)setPostParameters:(NSDictionary *)parameters error:(NSError *__autoreleasing *)error
+- (BOOL)setPostParameters:(NSDictionary *)parameters error:(NSError *__autoreleasing *)error
 {
     // make sure to always add the two parameters which should be included in each and every request
     NSMutableDictionary *allParameters = [parameters mutableCopy];
@@ -95,13 +95,17 @@ static const struct BNGDefaultParameterField BNGDefaultParameterField = {
      BNGDefaultParameterField.currencyCode: [APING sharedInstance].currencyCode,
      }];
     
-    if ([NSJSONSerialization isValidJSONObject:allParameters]) {
-        NSData *data = [NSJSONSerialization dataWithJSONObject:allParameters
-                                                       options:kNilOptions
-                                                         error:error];
-        
+    NSData *data = [NSJSONSerialization dataWithJSONObject:allParameters
+                                                   options:kNilOptions
+                                                     error:error];
+    
+    if (data) {
         [self setHTTPMethod:@"POST"];
         [self setHTTPBody:data];
+        
+        return YES;
+    } else {
+        return NO;
     }
 }
 


### PR DESCRIPTION
Code gets cleanly through the analyzer now.

CFURLCreate… returns an NSString with a refcount of 1.  So we need to __bridge to NSString and _transfer ownership to the caller.
Methods with NSError\* need to return a value (nil == fail : See NSError *, !nil == success).

Hope London is treating you well!

Cheers from SF,
Ian
